### PR TITLE
Corrigindo link quebrado para a pasta doc

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,8 +1,8 @@
 # Documentação do Projeto
 
 A documentação do projeto é composta pelos seguintes itens: 
- - [Diagramas de classe do projeto (histórico de versões)](/docs/diagramas/) **Obrigatório**
- - [Instruções para uso](/docs/instrucoes.md) **Obrigatório**
+ - [Diagramas de classe do projeto (histórico de versões)](/doc/diagramas/) **Obrigatório**
+ - [Instruções para uso](/doc/instrucoes.md) **Obrigatório**
  - [Quadro de tarefas do projeto](https://insira.aqui.sua.URL) **Obrigatório para trabalhos em grupo**
  - [Link para o vídeo de apresentação (edite este mesmo md para colocar sua URL)](http://insira.aqui.sua.URL) **Somente em caso de apresentação por vídeo**
 


### PR DESCRIPTION
Os links que referenciavam a pasta doc consideravam o nome "docs".